### PR TITLE
Implement MCP protocol foundation

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -48,15 +48,15 @@
 **Goal:** Implement MCP protocol basics
 
 **Tasks:**
-1. **MCP Types** - Define MCP protocol types in `mcp/types/`. Include Request, Response, Tool, Resource, and Error types.
+- [x] **MCP Types** - Define MCP protocol types in `mcp/types/`. Include Request, Response, Tool, Resource, and Error types.
 
-2. **MCP Client Base** - Create abstract MCP client in `mcp/client/BaseClient.ts`. Handle connection lifecycle and message framing.
+- [x] **MCP Client Base** - Create abstract MCP client in `mcp/client/BaseClient.ts`. Handle connection lifecycle and message framing.
 
-3. **MCP Server Base** - Build abstract MCP server in `mcp/server/BaseServer.ts`. Implement tool registration and request routing.
+- [x] **MCP Server Base** - Build abstract MCP server in `mcp/server/BaseServer.ts`. Implement tool registration and request routing.
 
-4. **Protocol Handler** - Develop message serialization in `mcp/protocol/Handler.ts` and `mcp/protocol/Validator.ts`.
+- [x] **Protocol Handler** - Develop message serialization in `mcp/protocol/Handler.ts` and `mcp/protocol/Validator.ts`.
 
-5. **Connection Manager** - Create connection pooling in `mcp/connections/Manager.ts` with health checking.
+- [x] **Connection Manager** - Create connection pooling in `mcp/connections/Manager.ts` with health checking.
 
 ### Wave 1.3: Foundation Testing
 **Goal:** Test core infrastructure

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,3 +1,6 @@
-# mcp
+# MCP Module
 
-This directory contains modules for mcp.
+This directory implements the Model Context Protocol (MCP) used for communication
+between the AI orchestration layer and external capabilities such as the browser
+server. It includes protocol message types, base client/server classes, and
+connection management utilities.

--- a/src/mcp/client/BaseClient.ts
+++ b/src/mcp/client/BaseClient.ts
@@ -1,0 +1,42 @@
+import { EventBus } from '../../events/EventBus';
+import { MCPRequest, MCPResponse } from '../types';
+
+/**
+ * Abstract MCP client handling connection lifecycle and message framing.
+ */
+export abstract class BaseClient {
+  protected bus: EventBus;
+  protected connected = false;
+
+  constructor(bus?: EventBus) {
+    this.bus = bus ?? new EventBus();
+  }
+
+  /** Establish connection to remote server. */
+  async connect(): Promise<void> {
+    if (this.connected) return;
+    await this.performConnect();
+    this.connected = true;
+  }
+
+  /** Close connection to remote server. */
+  async disconnect(): Promise<void> {
+    if (!this.connected) return;
+    await this.performDisconnect();
+    this.connected = false;
+  }
+
+  /** Check if the client is currently connected. */
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  /** Send a request and await response. */
+  abstract send(request: MCPRequest): Promise<MCPResponse>;
+
+  /** Implementation specific connection logic. */
+  protected abstract performConnect(): Promise<void>;
+
+  /** Implementation specific disconnect logic. */
+  protected abstract performDisconnect(): Promise<void>;
+}

--- a/src/mcp/client/README.md
+++ b/src/mcp/client/README.md
@@ -1,0 +1,3 @@
+# mcp/client
+
+Base client implementations for communicating over the MCP protocol.

--- a/src/mcp/connections/Manager.ts
+++ b/src/mcp/connections/Manager.ts
@@ -1,0 +1,42 @@
+import { BaseClient } from '../client/BaseClient';
+
+/**
+ * Manages a pool of MCP client connections.
+ */
+export class ConnectionManager {
+  private clients: Set<BaseClient> = new Set();
+
+  /** Add a client to the manager. */
+  add(client: BaseClient): void {
+    this.clients.add(client);
+  }
+
+  /** Remove a client from the manager. */
+  remove(client: BaseClient): void {
+    this.clients.delete(client);
+  }
+
+  /** Connect all registered clients. */
+  async connectAll(): Promise<void> {
+    for (const client of Array.from(this.clients)) {
+      await client.connect();
+    }
+  }
+
+  /** Disconnect all registered clients. */
+  async disconnectAll(): Promise<void> {
+    for (const client of Array.from(this.clients)) {
+      await client.disconnect();
+    }
+  }
+
+  /** Simple health check that all clients are connected. */
+  async healthCheck(): Promise<boolean> {
+    for (const client of Array.from(this.clients)) {
+      if (!client.isConnected()) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/mcp/connections/README.md
+++ b/src/mcp/connections/README.md
@@ -1,0 +1,3 @@
+# mcp/connections
+
+Connection management utilities for MCP clients.

--- a/src/mcp/connections/index.ts
+++ b/src/mcp/connections/index.ts
@@ -1,0 +1,1 @@
+export * from './Manager';

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './client/BaseClient';
+export * from './server/BaseServer';
+export * from './protocol';
+export * from './connections';

--- a/src/mcp/protocol/Handler.ts
+++ b/src/mcp/protocol/Handler.ts
@@ -1,0 +1,22 @@
+import { MCPRequest, MCPResponse } from '../types';
+
+/**
+ * Simple JSON protocol handler for encoding/decoding MCP messages.
+ */
+export class ProtocolHandler {
+  encodeRequest(req: MCPRequest): string {
+    return JSON.stringify(req);
+  }
+
+  decodeRequest(data: string): MCPRequest {
+    return JSON.parse(data) as MCPRequest;
+  }
+
+  encodeResponse(res: MCPResponse): string {
+    return JSON.stringify(res);
+  }
+
+  decodeResponse(data: string): MCPResponse {
+    return JSON.parse(data) as MCPResponse;
+  }
+}

--- a/src/mcp/protocol/README.md
+++ b/src/mcp/protocol/README.md
@@ -1,0 +1,3 @@
+# mcp/protocol
+
+Utilities for encoding, decoding, and validating MCP messages.

--- a/src/mcp/protocol/Validator.ts
+++ b/src/mcp/protocol/Validator.ts
@@ -1,0 +1,15 @@
+import { MCPRequest, MCPResponse } from '../types';
+
+/**
+ * Basic runtime validation for MCP messages.
+ * In a full implementation this would use JSON schema validation.
+ */
+export class Validator {
+  validateRequest(req: MCPRequest): boolean {
+    return typeof req.id === 'string' && typeof req.tool === 'string';
+  }
+
+  validateResponse(res: MCPResponse): boolean {
+    return typeof res.id === 'string' && typeof res.success === 'boolean';
+  }
+}

--- a/src/mcp/protocol/index.ts
+++ b/src/mcp/protocol/index.ts
@@ -1,0 +1,2 @@
+export * from './Handler';
+export * from './Validator';

--- a/src/mcp/server/BaseServer.ts
+++ b/src/mcp/server/BaseServer.ts
@@ -1,0 +1,48 @@
+import { EventBus } from '../../events/EventBus';
+import { MCPRequest, MCPResponse, MCPTool, MCPToolHandler, MCPError } from '../types';
+
+/**
+ * Base MCP server handling tool registration and routing requests.
+ */
+export abstract class BaseServer {
+  protected tools: Map<string, MCPToolHandler> = new Map();
+  protected bus: EventBus;
+
+  constructor(bus?: EventBus) {
+    this.bus = bus ?? new EventBus();
+  }
+
+  /** Register a tool and its handler. */
+  registerTool(tool: MCPTool, handler: MCPToolHandler): void {
+    this.tools.set(tool.name, handler);
+    this.bus.emit('toolRegistered', tool);
+  }
+
+  /** Handle an incoming request and return a response. */
+  async handle(request: MCPRequest): Promise<MCPResponse> {
+    const handler = this.tools.get(request.tool);
+    if (!handler) {
+      return {
+        id: request.id,
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Tool not registered' } as MCPError,
+      };
+    }
+    try {
+      const data = await handler(request.parameters ?? {});
+      return { id: request.id, success: true, data };
+    } catch (err: any) {
+      return {
+        id: request.id,
+        success: false,
+        error: { code: 'EXEC_ERROR', message: err.message, details: err },
+      };
+    }
+  }
+
+  /** Start accepting connections. */
+  abstract start(): Promise<void>;
+
+  /** Stop server and clean up. */
+  abstract stop(): Promise<void>;
+}

--- a/src/mcp/server/README.md
+++ b/src/mcp/server/README.md
@@ -1,0 +1,3 @@
+# mcp/server
+
+Base server infrastructure for exposing capabilities via MCP.

--- a/src/mcp/types/Error.ts
+++ b/src/mcp/types/Error.ts
@@ -1,0 +1,9 @@
+/** Error details for failed MCP responses */
+export interface MCPError {
+  /** Machine readable error code */
+  code: string;
+  /** Human readable message */
+  message: string;
+  /** Optional additional details */
+  details?: any;
+}

--- a/src/mcp/types/README.md
+++ b/src/mcp/types/README.md
@@ -1,0 +1,3 @@
+# mcp/types
+
+Type definitions for the Model Context Protocol.

--- a/src/mcp/types/Request.ts
+++ b/src/mcp/types/Request.ts
@@ -1,0 +1,8 @@
+export interface MCPRequest {
+  /** Unique ID for the request */
+  id: string;
+  /** Name of the tool being invoked */
+  tool: string;
+  /** Arbitrary parameters for the tool */
+  parameters?: Record<string, any>;
+}

--- a/src/mcp/types/Resource.ts
+++ b/src/mcp/types/Resource.ts
@@ -1,0 +1,9 @@
+/** Generic resource reference used in MCP */
+export interface MCPResource {
+  /** Type of the resource (e.g., 'page', 'image') */
+  type: string;
+  /** Resource location URL */
+  url: string;
+  /** Optional metadata about the resource */
+  metadata?: Record<string, any>;
+}

--- a/src/mcp/types/Response.ts
+++ b/src/mcp/types/Response.ts
@@ -1,0 +1,12 @@
+import { MCPError } from './Error';
+
+export interface MCPResponse<T = unknown> {
+  /** ID of the corresponding request */
+  id: string;
+  /** Whether the request succeeded */
+  success: boolean;
+  /** Response payload if success */
+  data?: T;
+  /** Error information if failed */
+  error?: MCPError;
+}

--- a/src/mcp/types/Tool.ts
+++ b/src/mcp/types/Tool.ts
@@ -1,0 +1,11 @@
+/** Description of a tool exposed via MCP */
+export interface MCPTool {
+  /** Unique tool name */
+  name: string;
+  /** Human readable description */
+  description: string;
+  /** JSON schema describing parameters */
+  parametersSchema?: Record<string, any>;
+}
+
+export type MCPToolHandler = (params: Record<string, any>) => Promise<any>;

--- a/src/mcp/types/index.ts
+++ b/src/mcp/types/index.ts
@@ -1,0 +1,5 @@
+export * from './Request';
+export * from './Response';
+export * from './Tool';
+export * from './Resource';
+export * from './Error';

--- a/tests/unit/mcp/BaseServer.test.ts
+++ b/tests/unit/mcp/BaseServer.test.ts
@@ -1,0 +1,18 @@
+import { BaseServer } from '../../../src/mcp/server/BaseServer';
+import { MCPTool } from '../../../src/mcp/types';
+
+class TestServer extends BaseServer {
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+}
+
+describe('BaseServer', () => {
+  it('should route requests to registered tools', async () => {
+    const server = new TestServer();
+    const tool: MCPTool = { name: 'echo', description: 'echo back' };
+    server.registerTool(tool, async params => params);
+    const resp = await server.handle({ id: '1', tool: 'echo', parameters: { a: 1 } });
+    expect(resp.success).toBe(true);
+    expect(resp.data).toEqual({ a: 1 });
+  });
+});

--- a/tests/unit/mcp/ConnectionManager.test.ts
+++ b/tests/unit/mcp/ConnectionManager.test.ts
@@ -1,0 +1,28 @@
+import { ConnectionManager } from '../../../src/mcp/connections/Manager';
+import { BaseClient } from '../../../src/mcp/client/BaseClient';
+import { MCPRequest, MCPResponse } from '../../../src/mcp/types';
+
+class DummyClient extends BaseClient {
+  protected async performConnect(): Promise<void> {
+    this.connected = true;
+  }
+  protected async performDisconnect(): Promise<void> {
+    this.connected = false;
+  }
+  async send(request: MCPRequest): Promise<MCPResponse> {
+    return { id: request.id, success: true };
+  }
+}
+
+describe('ConnectionManager', () => {
+  it('should manage client connections', async () => {
+    const manager = new ConnectionManager();
+    const client = new DummyClient();
+    manager.add(client);
+    await manager.connectAll();
+    const healthy = await manager.healthCheck();
+    expect(healthy).toBe(true);
+    await manager.disconnectAll();
+    expect(client.isConnected()).toBe(false);
+  });
+});

--- a/tests/unit/mcp/ProtocolHandler.test.ts
+++ b/tests/unit/mcp/ProtocolHandler.test.ts
@@ -1,0 +1,12 @@
+import { ProtocolHandler } from '../../../src/mcp/protocol/Handler';
+import { MCPRequest } from '../../../src/mcp/types';
+
+describe('ProtocolHandler', () => {
+  it('should encode and decode requests', () => {
+    const handler = new ProtocolHandler();
+    const req: MCPRequest = { id: '1', tool: 'ping' };
+    const encoded = handler.encodeRequest(req);
+    const decoded = handler.decodeRequest(encoded);
+    expect(decoded).toEqual(req);
+  });
+});

--- a/tests/unit/mcp/README.md
+++ b/tests/unit/mcp/README.md
@@ -1,0 +1,3 @@
+# tests/unit/mcp
+
+Unit tests covering core MCP protocol functionality.


### PR DESCRIPTION
## Summary
- add MCP types
- create base client and server infrastructure
- add protocol handler and validator
- implement connection manager
- write unit tests for MCP modules
- update dev plan

## Testing
- `npm test` *(fails: jest not found)*