### PR TITLE
Implement mock MCP server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,5 +166,6 @@ Current progress:
 * `package.json` and `tsconfig.json` have been configured.
 * Core event system implemented.
 * Logger, configuration manager, and base interfaces added.
+* Foundation tests and mock MCP server implemented.
 
 ---

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -62,10 +62,10 @@
 **Goal:** Test core infrastructure
 
 **Tasks:**
-1. **Event System Tests** - Unit tests for event bus functionality
-2. **Config Tests** - Configuration loading and validation tests
-3. **MCP Protocol Tests** - Message serialization and validation tests
-4. **Mock MCP Server** - Test server for development in `test/mocks/`
+- [x] **Event System Tests** - Unit tests for event bus functionality
+- [x] **Config Tests** - Configuration loading and validation tests
+- [x] **MCP Protocol Tests** - Message serialization and validation tests
+- [x] **Mock MCP Server** - Test server for development in `test/mocks/`
 
 ---
 

--- a/tests/mocks/MockMCPServer.ts
+++ b/tests/mocks/MockMCPServer.ts
@@ -1,0 +1,43 @@
+import { BaseServer } from '../../src/mcp/server/BaseServer';
+import { EventBus } from '../../src/events/EventBus';
+import { MCPToolHandler, MCPTool } from '../../src/mcp/types';
+
+/**
+ * Simple in-memory mock MCP server for testing purposes.
+ * It extends BaseServer and exposes start/stop lifecycle methods
+ * without any network connectivity.
+ */
+export class MockMCPServer extends BaseServer {
+  private started = false;
+
+  constructor(bus?: EventBus) {
+    super(bus);
+  }
+
+  /** Start the mock server. */
+  async start(): Promise<void> {
+    this.started = true;
+    this.bus.emit('serverStarted');
+  }
+
+  /** Stop the mock server. */
+  async stop(): Promise<void> {
+    this.started = false;
+    this.bus.emit('serverStopped');
+  }
+
+  /**
+   * Convenience helper to register a tool with a given handler.
+   */
+  register(name: string, description: string, handler: MCPToolHandler): void {
+    const tool: MCPTool = { name, description };
+    super.registerTool(tool, handler);
+  }
+
+  /**
+   * Indicates whether the server has been started.
+   */
+  isRunning(): boolean {
+    return this.started;
+  }
+}

--- a/tests/unit/mcp/MockMCPServer.test.ts
+++ b/tests/unit/mcp/MockMCPServer.test.ts
@@ -1,0 +1,22 @@
+import { MockMCPServer } from '../../mocks/MockMCPServer';
+import { MCPRequest } from '../../../src/mcp/types';
+
+describe('MockMCPServer', () => {
+  it('should start and stop correctly', async () => {
+    const server = new MockMCPServer();
+    await server.start();
+    expect(server.isRunning()).toBe(true);
+    await server.stop();
+    expect(server.isRunning()).toBe(false);
+  });
+
+  it('should handle registered tools', async () => {
+    const server = new MockMCPServer();
+    server.register('ping', 'responds with pong', async () => 'pong');
+    await server.start();
+    const request: MCPRequest = { id: '1', tool: 'ping' };
+    const response = await server.handle(request);
+    expect(response.success).toBe(true);
+    expect(response.data).toBe('pong');
+  });
+});


### PR DESCRIPTION
## Summary
- implement simple MockMCPServer for tests
- add unit tests for MockMCPServer
- update development plan with completed tasks
- note progress update in AGENTS.md

## Testing
- `npm test` *(fails: jest not found)*