### PR TITLE
Implement mock MCP server and update dev plan

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -62,10 +62,10 @@
 **Goal:** Test core infrastructure
 
 **Tasks:**
-1. **Event System Tests** - Unit tests for event bus functionality
-2. **Config Tests** - Configuration loading and validation tests
-3. **MCP Protocol Tests** - Message serialization and validation tests
-4. **Mock MCP Server** - Test server for development in `test/mocks/`
+- [x] **Event System Tests** - Unit tests for event bus functionality
+- [x] **Config Tests** - Configuration loading and validation tests
+- [x] **MCP Protocol Tests** - Message serialization and validation tests
+- [x] **Mock MCP Server** - Test server for development in `test/mocks/`
 
 ---
 

--- a/tests/mocks/MockMCPServer.ts
+++ b/tests/mocks/MockMCPServer.ts
@@ -1,0 +1,21 @@
+import { BaseServer } from "../../src/mcp/server/BaseServer";
+
+/**
+ * Simple mock MCP server for tests.
+ * Provides start/stop lifecycle and can register tools via BaseServer.
+ */
+export class MockMCPServer extends BaseServer {
+  public started = false;
+
+  /** Start the mock server. */
+  async start(): Promise<void> {
+    this.started = true;
+    this.bus.emit('started');
+  }
+
+  /** Stop the mock server. */
+  async stop(): Promise<void> {
+    this.started = false;
+    this.bus.emit('stopped');
+  }
+}

--- a/tests/unit/mcp/MockServer.test.ts
+++ b/tests/unit/mcp/MockServer.test.ts
@@ -1,0 +1,21 @@
+import { MockMCPServer } from '../../mocks/MockMCPServer';
+import { MCPTool } from '../../../src/mcp/types';
+
+describe('MockMCPServer', () => {
+  it('should start and stop correctly', async () => {
+    const server = new MockMCPServer();
+    await server.start();
+    expect(server.started).toBe(true);
+    await server.stop();
+    expect(server.started).toBe(false);
+  });
+
+  it('should handle registered tool requests', async () => {
+    const server = new MockMCPServer();
+    const tool: MCPTool = { name: 'ping', description: 'return pong' };
+    server.registerTool(tool, async () => 'pong');
+    const resp = await server.handle({ id: '1', tool: 'ping' });
+    expect(resp.success).toBe(true);
+    expect(resp.data).toBe('pong');
+  });
+});


### PR DESCRIPTION
## Summary
- add a mock MCP server for tests
- add tests covering the mock server
- mark foundation testing tasks complete in DEV_PLAN

## Testing
- `npm test` *(fails: jest not found)*